### PR TITLE
Refactor code to remove duplicate code and improve year of birth comparison testing

### DIFF
--- a/R/mod_analysisSettings_CodeWAS.R
+++ b/R/mod_analysisSettings_CodeWAS.R
@@ -198,7 +198,6 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
       nSubjectsCase <- cohortTableHandler$getNumberOfSubjects(input$selectCaseCohort_pickerInput)
       nSubjectsControl <- cohortTableHandler$getNumberOfSubjects(input$selectControlCohort_pickerInput)
 
-
       # cores
       message <- paste0("\u2139\uFE0F Analysis will use : ", cores, " cores\n")
 
@@ -274,19 +273,19 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
                             "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
           )
           if (small_d) {
-            message <- paste0(message, "\u2139\uFE0F Effect size is small — practical difference may be negligible.\n")
+            message <- paste0(message, "\u2139\uFE0F Effect size is small - practical difference may be negligible.\n")
           } else {
             message <- paste0(message, "\n=> Consider adjusting for year of birth with the regression analysis option or re-matching controls.\n")
           }
         } else if (sig_t && sig_ks) {
           message <- paste0(message,
-                            "\u26A0\uFE0F There is significant difference both in the mean year of birth between case and control cohorts (t-test) — and the shapes of year of birth distributions (KS test).\n",
+                            "\u26A0\uFE0F There is significant difference both in the mean year of birth between case and control cohorts (t-test) - and the shapes of year of birth distributions (KS test).\n",
                             "- t-test p = ", scales::scientific(p_ttest), "\n",
                             "- KS test p = ", scales::scientific(p_ks), "\n",
                             "- Cohen's d = ", round(cohen_d, 3)," (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2)  \n"
           )
           if (small_d) {
-            message <- paste0(message, "\u2139\uFE0F Effect size is small — practical difference may be negligible but the birth year distributions are significantly different .\n")
+            message <- paste0(message, "\u2139\uFE0F Effect size is small - practical difference may be negligible but the birth year distributions are significantly different .\n")
           }
           message <- paste0(message, "\n=> Consider adjusting for year of birth with the regression analysis option or re-matching controls.\n")
         }

--- a/R/mod_analysisSettings_CodeWAS.R
+++ b/R/mod_analysisSettings_CodeWAS.R
@@ -261,7 +261,7 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
                             "\u26A0\uFE0F There is a significant difference in the shapes of year of birth distributions between the case and control cohorts (KS test), but the mean year of births are similar (t-test).\n",
                             "- t-test p = ", scales::scientific(p_ttest), "\n",
                             "- KS test p = ", scales::scientific(p_ks), "\n",
-                            "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
+                            "- Cohen's d = ", round(d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
           )
             message <- paste0(message, "\n=> Consider adjusting for year of birth with the regression analysis option or re-matching controls if the Cohen's d effect size is greater than 0.2.\n")
 
@@ -270,7 +270,7 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
                             "\u26A0\uFE0F There is a significant difference in the mean year of birth between case and control cohorts (t-test), but year of birth distributions are similar in shape (KS test).\n",
                             "- t-test p = ", scales::scientific(p_ttest), "\n",
                             "- KS test p = ", scales::scientific(p_ks), "\n",
-                            "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
+                            "- Cohen's d = ", round(d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
           )
           if (small_d) {
             message <- paste0(message, "\u2139\uFE0F Effect size is small - practical difference may be negligible.\n")
@@ -282,7 +282,7 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
                             "\u26A0\uFE0F There is significant difference both in the mean year of birth between case and control cohorts (t-test) - and the shapes of year of birth distributions (KS test).\n",
                             "- t-test p = ", scales::scientific(p_ttest), "\n",
                             "- KS test p = ", scales::scientific(p_ks), "\n",
-                            "- Cohen's d = ", round(cohen_d, 3)," (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2)  \n"
+                            "- Cohen's d = ", round(d, 3)," (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2)  \n"
           )
           if (small_d) {
             message <- paste0(message, "\u2139\uFE0F Effect size is small - practical difference may be negligible but the birth year distributions are significantly different .\n")

--- a/R/mod_analysisSettings_CodeWAS.R
+++ b/R/mod_analysisSettings_CodeWAS.R
@@ -45,11 +45,11 @@ mod_analysisSettings_codeWAS_ui <- function(id) {
         801, 841, 909,
         501, 541, 907,
         910, 911 ),
-        analysisRegexToShowTibble  = tibble::tribble(
-          ~analysisId, ~analysisName, ~analysisRegex,
-          999, "Endpoints", "^(?!.*\\[CohortLibrary\\]).*_case$",
-          998, "CohortLibrary", ".*\\[CohortLibrary\\]"
-        ),
+      analysisRegexToShowTibble  = tibble::tribble(
+        ~analysisId, ~analysisName, ~analysisRegex,
+        999, "Endpoints", "^(?!.*\\[CohortLibrary\\]).*_case$",
+        998, "CohortLibrary", ".*\\[CohortLibrary\\]"
+      ),
       analysisIdsSelected = c(141, 1, 2, 8, 10, 41, 641, 342, 701, 702, 841, 541, 999)
     ),
     shinyWidgets::radioGroupButtons(
@@ -160,7 +160,7 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
       cohortIdAndNamesList <- cohortIdAndNamesList |>
         purrr::discard(~.x %in% input$selectCaseCohort_pickerInput)
 
-      # Add cohort 0 with 
+      # Add cohort 0 with
       cohortIdAndNamesList <- c(list(`AUTO-MATCH: Creates a control cohort from the patiens not in case cohort that matches case cohort by sex and birth year with ratio 1:10` = 0), cohortIdAndNamesList)
 
       shinyWidgets::updatePickerInput(
@@ -186,31 +186,18 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
     # Create advice message
     #
     output$info_text <- shiny::renderText({
-      if (!shiny::isTruthy(r_connectionHandler$hasChangeCounter) || 
-      !shiny::isTruthy(input$selectCaseCohort_pickerInput) || 
-      !shiny::isTruthy(input$selectControlCohort_pickerInput)) {
+      if (!shiny::isTruthy(r_connectionHandler$hasChangeCounter) ||
+          !shiny::isTruthy(input$selectCaseCohort_pickerInput) ||
+          !shiny::isTruthy(input$selectControlCohort_pickerInput)) {
         return("")
       }
 
       cohortTableHandler <- r_connectionHandler$cohortTableHandler
 
-      cohortsOverlap <- cohortTableHandler$getCohortsOverlap()
-      cohortCounts <-  cohortTableHandler$getCohortCounts()
-      nSubjectsOverlap <- cohortsOverlap |>
-        dplyr::filter(
-          stringr::str_detect(cohortIdCombinations, paste0("-", input$selectCaseCohort_pickerInput, "-")) &
-            stringr::str_detect(cohortIdCombinations, paste0("-", input$selectControlCohort_pickerInput, "-"))
-        ) |>
-        dplyr::pull(numberOfSubjects)  |>
-        sum()
-      nSubjectsCase <- cohortCounts |>
-        dplyr::filter(cohortId == input$selectCaseCohort_pickerInput) |>
-        dplyr::pull(cohortSubjects)
-      nSubjectsControl <- cohortCounts |>
-        dplyr::filter(cohortId == input$selectControlCohort_pickerInput) |>
-        dplyr::pull(cohortSubjects)
+      nSubjectsOverlap <- cohortTableHandler$getNumberOfOverlappingSubjects(selected_cohortId1=input$selectCaseCohort_pickerInput,selected_cohortId2=input$selectControlCohort_pickerInput)
+      nSubjectsCase <- cohortTableHandler$getNumberOfSubjects(input$selectCaseCohort_pickerInput)
+      nSubjectsControl <- cohortTableHandler$getNumberOfSubjects(input$selectControlCohort_pickerInput)
 
-      cohortsSumary  <- cohortTableHandler$getCohortsSummary()
 
       # cores
       message <- paste0("\u2139\uFE0F Analysis will use : ", cores, " cores\n")
@@ -238,23 +225,9 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
 
       # sex
       if(!(input$statistics_type_option == "full" & input$controlSex_checkboxInput)){
-        sexCase <- cohortsSumary |>
-          dplyr::filter(cohortId == input$selectCaseCohort_pickerInput) |>
-          dplyr::pull(sexCounts)
-        sexControl <- cohortsSumary |>
-          dplyr::filter(cohortId == input$selectControlCohort_pickerInput) |>
-          dplyr::pull(sexCounts)
-        nMaleCases <- sexCase[[1]]  |> dplyr::filter(sex == "MALE")  |> dplyr::pull(n)
-        nMaleCases <- ifelse(length(nMaleCases)==0, 0, nMaleCases)
-        nFemaleCases <- sexCase[[1]]  |> dplyr::filter(sex == "FEMALE")  |> dplyr::pull(n)
-        nFemaleCases <- ifelse(length(nFemaleCases)==0, 0, nFemaleCases)
-        nMaleControls <- sexControl[[1]]  |> dplyr::filter(sex == "MALE") |> dplyr::pull(n)
-        nMaleControls <- ifelse(length(nMaleControls)==0, 0, nMaleControls)
-        nFemaleControls <- sexControl[[1]]  |> dplyr::filter(sex == "FEMALE") |> dplyr::pull(n)
-        nFemaleControls <- ifelse(length(nFemaleControls)==0, 0, nFemaleControls)
 
-        data <-matrix(c(nMaleCases,nFemaleCases,nMaleControls,nFemaleControls),ncol=2)
-        fisher_results <- stats::fisher.test(data)
+        fisher_results = cohortTableHandler$getSexFisherTest(selected_cohortId1=input$selectCaseCohort_pickerInput,
+                                                             selected_cohortId2=input$selectControlCohort_pickerInput)
 
         if(fisher_results$p.value < 0.05){
           message <- paste0(message, "\u26A0\uFE0F There is a significant difference in sex distribution between case and control cohorts. (Fisher's test p = ", scales::scientific(fisher_results$p.value)," ) \n")
@@ -264,19 +237,61 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
 
       # year of birth
       if(!(input$statistics_type_option == "full" & input$controlYearOfBirth_checkboxInput)){
-        yearOfBirthCase <- cohortsSumary |>
-          dplyr::filter(cohortId == input$selectCaseCohort_pickerInput) |>
-          dplyr::pull(histogramBirthYear)
-        yearOfBirthControl <- cohortsSumary |>
-          dplyr::filter(cohortId == input$selectControlCohort_pickerInput) |>
-          dplyr::pull(histogramBirthYear)
 
-        ttestResult <- t.test(yearOfBirthCase[[1]]  |> tidyr::uncount(n), yearOfBirthControl[[1]]  |> tidyr::uncount(n))
+        yearOfBirthComparison_results = cohortTableHandler$getYearOfBirthTests(selected_cohortId1=input$selectCaseCohort_pickerInput,
+                                                             selected_cohortId2=input$selectControlCohort_pickerInput)
 
-        if(ttestResult$p.value < 0.05){
-          message <- paste0(message, "\u26A0\uFE0F There is a significant difference in year of birth distribution between case and control cohorts. (t-test p = ", scales::scientific(ttestResult$p.value)," ) \n")
-          message <- paste0(message, "Consider controling for year of birth using regresion statistics or creating a new control cohort that match case cohort by year of birth in the Match Cohorts tab\n")
+
+        ttestResult <- yearOfBirthComparison_results[["ttestResult"]]
+        ks_result <- yearOfBirthComparison_results[["ksResult"]]
+        cohen_d  <- yearOfBirthComparison_results[["cohendResult"]]["cohend"]
+        meanCases <- yearOfBirthComparison_results[["cohendResult"]]["meanInCases"]
+        meanControls <- yearOfBirthComparison_results[["cohendResult"]]["meanInControls"]
+        pooled_sd <- yearOfBirthComparison_results[["cohendResult"]]["pooledsd"]
+
+        p_ttest <- ttestResult$p.value
+        p_ks <- ks_result$p.value
+        d <- abs(cohen_d)
+
+        sig_t <- p_ttest < 0.05
+        sig_ks <- p_ks < 0.05
+        small_d <- d < 0.2
+
+        if (sig_ks && !sig_t) {
+          message <- paste0(message,
+                            "\u26A0\uFE0F There is a significant difference in the shapes of year of birth distributions between the case and control cohorts (KS test), but the mean year of births are similar (t-test).\n",
+                            "- t-test p = ", scales::scientific(p_ttest), "\n",
+                            "- KS test p = ", scales::scientific(p_ks), "\n",
+                            "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
+          )
+            message <- paste0(message, "\n=> Consider adjusting for year of birth with the regression analysis option or re-matching controls if the Cohen's d effect size is greater than 0.2.\n")
+
+        } else if (sig_t && !sig_ks) {
+          message <- paste0(message,
+                            "\u26A0\uFE0F There is a significant difference in the mean year of birth between case and control cohorts (t-test), but year of birth distributions are similar in shape (KS test).\n",
+                            "- t-test p = ", scales::scientific(p_ttest), "\n",
+                            "- KS test p = ", scales::scientific(p_ks), "\n",
+                            "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
+          )
+          if (small_d) {
+            message <- paste0(message, "\u2139\uFE0F Effect size is small — practical difference may be negligible.\n")
+          } else {
+            message <- paste0(message, "\n=> Consider adjusting for year of birth with the regression analysis option or re-matching controls.\n")
+          }
+        } else if (sig_t && sig_ks) {
+          message <- paste0(message,
+                            "\u26A0\uFE0F There is significant difference both in the mean year of birth between case and control cohorts (t-test) — and the shapes of year of birth distributions (KS test).\n",
+                            "- t-test p = ", scales::scientific(p_ttest), "\n",
+                            "- KS test p = ", scales::scientific(p_ks), "\n",
+                            "- Cohen's d = ", round(cohen_d, 3)," (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2)  \n"
+          )
+          if (small_d) {
+            message <- paste0(message, "\u2139\uFE0F Effect size is small — practical difference may be negligible but the birth year distributions are significantly different .\n")
+          }
+          message <- paste0(message, "\n=> Consider adjusting for year of birth with the regression analysis option or re-matching controls.\n")
         }
+
+
       }
       return(message)
     })
@@ -317,7 +332,7 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
         covariatesIds = covariatesIds,
         minCellCount = input$minCellCount_numericInput,
         chunksSizeNOutcomes = chunksSizeNOutcomes,
-        cores = cores, 
+        cores = cores,
         analysisRegexTibble  = tibble::tribble(
           ~analysisId, ~analysisName, ~analysisRegex,
           999, "Endpoints", "^(?!.*\\[CohortLibrary\\]).*_case$",
@@ -333,7 +348,6 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
 
   })
 }
-
 
 
 

--- a/R/mod_analysisSettings_CodeWAS.R
+++ b/R/mod_analysisSettings_CodeWAS.R
@@ -208,7 +208,7 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
 
       # counts
       if( nSubjectsCase > nSubjectsControl ){
-        message <- paste0(message, "\u274C There are more subjects in  case cohort (", nSubjectsCase,") that in control cohort (", nSubjectsControl,"). Are you sure they are correct?\n")
+        message <- paste0(message, "\u274C There are more subjects in  case cohort (", nSubjectsCase,") than in control cohort (", nSubjectsControl,"). Are you sure they are correct?\n")
       }
 
       # overlap
@@ -216,7 +216,7 @@ mod_analysisSettings_codeWAS_server <- function(id, r_connectionHandler) {
         message <- paste0(message, "\u2705 No subjects overlap between case and control cohorts\n")
       }else{
         if(nSubjectsOverlap > nSubjectsCase * .20){
-          message <- paste0(message, "\u274C There are many subjects, ",nSubjectsOverlap, ", that overlap  berween case and control cohorts. Consider removing them in Operate Cohorts tab\n")
+          message <- paste0(message, "\u274C There are many subjects, ",nSubjectsOverlap, ", that overlap  between case and control cohorts. Consider removing them in Operate Cohorts tab\n")
         }else{
           message <- paste0(message, "\u26A0\uFE0F There are few subjects, ",nSubjectsOverlap, ", that overlap between case and control cohorts. \n")
         }

--- a/R/mod_analysisSettings_TimeCodeWAS.R
+++ b/R/mod_analysisSettings_TimeCodeWAS.R
@@ -221,7 +221,7 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
                           "\u26A0\uFE0F There is a significant difference in the shapes of year of birth distributions between the case and control cohorts (KS test), but the mean year of births are similar (t-test).\n",
                           "- t-test p = ", scales::scientific(p_ttest), "\n",
                           "- KS test p = ", scales::scientific(p_ks), "\n",
-                          "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
+                          "- Cohen's d = ", round(d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
         )
         message <- paste0(message, "\n=> Consider creating a matched control cohort by year of birth (in the Match Cohorts tab) if the Cohen's d effect size is greater than 0.2. \n")
 
@@ -230,7 +230,7 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
                           "\u26A0\uFE0F There is a significant difference in the mean year of birth between case and control cohorts (t-test), but year of birth distributions are similar in shape (KS test).\n",
                           "- t-test p = ", scales::scientific(p_ttest), "\n",
                           "- KS test p = ", scales::scientific(p_ks), "\n",
-                          "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
+                          "- Cohen's d = ", round(d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
         )
         if (small_d) {
           message <- paste0(message, "\u2139\uFE0F Effect size is small - practical difference may be negligible.\n")
@@ -242,7 +242,7 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
                           "\u26A0\uFE0F There is significant difference both in the mean year of birth between case and control cohorts (t-test) - and the shapes of year of birth distributions (KS test).\n",
                           "- t-test p = ", scales::scientific(p_ttest), "\n",
                           "- KS test p = ", scales::scientific(p_ks), "\n",
-                          "- Cohen's d = ", round(cohen_d, 3)," (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2)  \n"
+                          "- Cohen's d = ", round(d, 3)," (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2)  \n"
         )
         if (small_d) {
           message <- paste0(message, "\u2139\uFE0F Effect size is small - practical difference may be negligible but the birth year distributions are significantly different .\n")

--- a/R/mod_analysisSettings_TimeCodeWAS.R
+++ b/R/mod_analysisSettings_TimeCodeWAS.R
@@ -124,7 +124,7 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
       cohortIdAndNamesList <- cohortIdAndNamesList |>
         purrr::discard(~.x %in% input$selectCaseCohort_pickerInput)
 
-      # Add cohort 0 with 
+      # Add cohort 0 with
       cohortIdAndNamesList <- c(list(`AUTO-MATCH: Creates a control cohort from the patiens not in case cohort that matches case cohort by sex and birth year with ratio 1:10 and start date as in case cohort` = 0), cohortIdAndNamesList)
 
       shinyWidgets::updatePickerInput(
@@ -148,39 +148,20 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
     # Create advice message
     #
     output$info_text <- shiny::renderText({
-       if (!shiny::isTruthy(r_connectionHandler$hasChangeCounter) || 
-      !shiny::isTruthy(input$selectCaseCohort_pickerInput) || 
+       if (!shiny::isTruthy(r_connectionHandler$hasChangeCounter) ||
+      !shiny::isTruthy(input$selectCaseCohort_pickerInput) ||
       !shiny::isTruthy(input$selectControlCohort_pickerInput)) {
         return("")
       }
 
       cohortTableHandler <- r_connectionHandler$cohortTableHandler
 
-      cohortsOverlap <- cohortTableHandler$getCohortsOverlap()
-      cohortCounts <-  cohortTableHandler$getCohortCounts()
-      nSubjectsOverlap <- cohortsOverlap |>
-        dplyr::filter(
-          stringr::str_detect(cohortIdCombinations, paste0("-", input$selectCaseCohort_pickerInput, "-")) &
-            stringr::str_detect(cohortIdCombinations, paste0("-", input$selectControlCohort_pickerInput, "-"))
-        ) |>
-        dplyr::pull(numberOfSubjects)  |>
-        sum()
-      nSubjectsCase <- cohortCounts |>
-        dplyr::filter(cohortId == input$selectCaseCohort_pickerInput) |>
-        dplyr::pull(cohortSubjects)
-      nSubjectsControl <- cohortCounts |>
-        dplyr::filter(cohortId == input$selectControlCohort_pickerInput) |>
-        dplyr::pull(cohortSubjects)
 
-      nEntryCase <- cohortCounts |>
-        dplyr::filter(cohortId == input$selectCaseCohort_pickerInput) |>
-        dplyr::pull(cohortEntries)
-      nEntryControl <- cohortCounts |>
-        dplyr::filter(cohortId == input$selectControlCohort_pickerInput) |>
-        dplyr::pull(cohortEntries)
-
-
-      cohortsSumary  <- cohortTableHandler$getCohortsSummary()
+      nSubjectsOverlap <- cohortTableHandler$getNumberOfOverlappingSubjects(selected_cohortId1=input$selectCaseCohort_pickerInput,selected_cohortId2=input$selectControlCohort_pickerInput)
+      nSubjectsCase <- cohortTableHandler$getNumberOfSubjects(input$selectCaseCohort_pickerInput)
+      nSubjectsControl <- cohortTableHandler$getNumberOfSubjects(input$selectControlCohort_pickerInput)
+      nEntryCase <- cohortTableHandler$getNumberOfCohortEntries(input$selectCaseCohort_pickerInput)
+      nEntryControl <- cohortTableHandler$getNumberOfCohortEntries(input$selectControlCohort_pickerInput)
 
       message <- ""
       if(input$selectControlCohort_pickerInput == 0){
@@ -205,43 +186,68 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
       }
 
       # sex
-      sexCase <- cohortsSumary |>
-        dplyr::filter(cohortId == input$selectCaseCohort_pickerInput) |>
-        dplyr::pull(sexCounts)
-      sexControl <- cohortsSumary |>
-        dplyr::filter(cohortId == input$selectControlCohort_pickerInput) |>
-        dplyr::pull(sexCounts)
-      nMaleCases <- sexCase[[1]]  |> dplyr::filter(sex == "MALE")  |> dplyr::pull(n)
-      nMaleCases <- ifelse(length(nMaleCases)==0, 0, nMaleCases)
-      nFemaleCases <- sexCase[[1]]  |> dplyr::filter(sex == "FEMALE")  |> dplyr::pull(n)
-      nFemaleCases <- ifelse(length(nFemaleCases)==0, 0, nFemaleCases)
-      nMaleControls <- sexControl[[1]]  |> dplyr::filter(sex == "MALE") |> dplyr::pull(n)
-      nMaleControls <- ifelse(length(nMaleControls)==0, 0, nMaleControls)
-      nFemaleControls <- sexControl[[1]]  |> dplyr::filter(sex == "FEMALE") |> dplyr::pull(n)
-      nFemaleControls <- ifelse(length(nFemaleControls)==0, 0, nFemaleControls)
-
-      data <-matrix(c(nMaleCases,nFemaleCases,nMaleControls,nFemaleControls),ncol=2)
-      fisher_results <- stats::fisher.test(data)
+      fisher_results = cohortTableHandler$getSexFisherTest(selected_cohortId1=input$selectCaseCohort_pickerInput,
+                                                           selected_cohortId2=input$selectControlCohort_pickerInput)
 
       if(fisher_results$p.value < 0.05){
         message <- paste0(message, "\u26A0\uFE0F There is a significant difference in sex distribution between case and control cohorts. (Fisher's test p = ", scales::scientific(fisher_results$p.value)," ) \n")
         message <- paste0(message, "Consider controling for sex  creating a new control cohort that match case cohort by sex in the Match Cohorts tab\n")
       }
 
+
       # year of birth
-      yearOfBirthCase <- cohortsSumary |>
-        dplyr::filter(cohortId == input$selectCaseCohort_pickerInput) |>
-        dplyr::pull(histogramBirthYear)
-      yearOfBirthControl <- cohortsSumary |>
-        dplyr::filter(cohortId == input$selectControlCohort_pickerInput) |>
-        dplyr::pull(histogramBirthYear)
+      yearOfBirthComparison_results = cohortTableHandler$getYearOfBirthTests(selected_cohortId1=input$selectCaseCohort_pickerInput,
+                                                                             selected_cohortId2=input$selectControlCohort_pickerInput)
 
-      ttestResult <- t.test(yearOfBirthCase[[1]]  |> tidyr::uncount(n), yearOfBirthControl[[1]]  |> tidyr::uncount(n))
+      ttestResult <- yearOfBirthComparison_results[["ttestResult"]]
+      ks_result <- yearOfBirthComparison_results[["ksResult"]]
+      cohen_d  <- yearOfBirthComparison_results[["cohendResult"]]["cohend"]
+      meanCases <- yearOfBirthComparison_results[["cohendResult"]]["meanInCases"]
+      meanControls <- yearOfBirthComparison_results[["cohendResult"]]["meanInControls"]
+      pooled_sd <- yearOfBirthComparison_results[["cohendResult"]]["pooledsd"]
 
-      if(ttestResult$p.value < 0.05){
-        message <- paste0(message, "\u26A0\uFE0F There is a significant difference in year of birth distribution between case and control cohorts. (t-test p = ", scales::scientific(ttestResult$p.value)," ) \n")
-        message <- paste0(message, "Consider controling for year of birth creating a new control cohort that match case cohort by year of birth in the Match Cohorts tab\n")
+      p_ttest <- ttestResult$p.value
+      p_ks <- ks_result$p.value
+      d <- abs(cohen_d)
+
+      sig_t <- p_ttest < 0.05
+      sig_ks <- p_ks < 0.05
+      small_d <- d < 0.2
+
+      if (sig_ks && !sig_t) {
+        message <- paste0(message,
+                          "\u26A0\uFE0F There is a significant difference in the shapes of year of birth distributions between the case and control cohorts (KS test), but the mean year of births are similar (t-test).\n",
+                          "- t-test p = ", scales::scientific(p_ttest), "\n",
+                          "- KS test p = ", scales::scientific(p_ks), "\n",
+                          "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
+        )
+        message <- paste0(message, "\n=> Consider creating a matched control cohort by year of birth (in the Match Cohorts tab) if the Cohen's d effect size is greater than 0.2. \n")
+
+      } else if (sig_t && !sig_ks) {
+        message <- paste0(message,
+                          "\u26A0\uFE0F There is a significant difference in the mean year of birth between case and control cohorts (t-test), but year of birth distributions are similar in shape (KS test).\n",
+                          "- t-test p = ", scales::scientific(p_ttest), "\n",
+                          "- KS test p = ", scales::scientific(p_ks), "\n",
+                          "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
+        )
+        if (small_d) {
+          message <- paste0(message, "\u2139\uFE0F Effect size is small — practical difference may be negligible.\n")
+        } else {
+          message <- paste0(message, "\n=> Consider controlling for year of birth by creating a new control cohort matching the case cohort by year of birth in the Match Cohorts tab.\n")
+        }
+      } else if (sig_t && sig_ks) {
+        message <- paste0(message,
+                          "\u26A0\uFE0F There is significant difference both in the mean year of birth between case and control cohorts (t-test) — and the shapes of year of birth distributions (KS test).\n",
+                          "- t-test p = ", scales::scientific(p_ttest), "\n",
+                          "- KS test p = ", scales::scientific(p_ks), "\n",
+                          "- Cohen's d = ", round(cohen_d, 3)," (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2)  \n"
+        )
+        if (small_d) {
+          message <- paste0(message, "\u2139\uFE0F Effect size is small — practical difference may be negligible but the birth year distributions are significantly different .\n")
+        }
+        message <- paste0(message, "\n=> Consider controlling for year of birth by creating a new control cohort matching the case cohort by year of birth in the Match Cohorts tab.\n")
       }
+
 
       return(message)
 

--- a/R/mod_analysisSettings_TimeCodeWAS.R
+++ b/R/mod_analysisSettings_TimeCodeWAS.R
@@ -163,7 +163,6 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
       nEntryCase <- cohortTableHandler$getNumberOfCohortEntries(input$selectCaseCohort_pickerInput)
       nEntryControl <- cohortTableHandler$getNumberOfCohortEntries(input$selectControlCohort_pickerInput)
 
-
       message <- ""
       if(input$selectControlCohort_pickerInput == 0){
         message <- paste0(message, "\u2139\uFE0F Analysis will create a control cohort from the patients not in case cohort that matches case cohort by sex and birth year with ratio 1:10 and start date as in case cohort\n")
@@ -172,7 +171,7 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
 
       # counts
       if( nEntryCase > nEntryControl ){
-        message <- paste0(message, "There are more entries in case cohort (", nEntryCase,") that in control cohort (", nEntryControl,"). Are you sure they are correct?\n")
+        message <- paste0(message, "There are more entries in case cohort (", nEntryCase,") than in control cohort (", nEntryControl,"). Are you sure they are correct?\n")
       }
 
       # overlap
@@ -188,7 +187,8 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
 
       # sex
       fisher_results = cohortTableHandler$getSexFisherTest(selected_cohortId1=input$selectCaseCohort_pickerInput,
-                                                           selected_cohortId2=input$selectControlCohort_pickerInput)
+                                                           selected_cohortId2=input$selectControlCohort_pickerInput,
+                                                           testFor="allEvents")
 
       if(fisher_results$p.value < 0.05){
         message <- paste0(message, "\u26A0\uFE0F There is a significant difference in sex distribution between case and control cohorts. (Fisher's test p = ", scales::scientific(fisher_results$p.value)," ) \n")
@@ -198,7 +198,8 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
 
       # year of birth
       yearOfBirthComparison_results = cohortTableHandler$getYearOfBirthTests(selected_cohortId1=input$selectCaseCohort_pickerInput,
-                                                                             selected_cohortId2=input$selectControlCohort_pickerInput)
+                                                                             selected_cohortId2=input$selectControlCohort_pickerInput,
+                                                                             testFor="allEvents")
 
       ttestResult <- yearOfBirthComparison_results[["ttestResult"]]
       ks_result <- yearOfBirthComparison_results[["ksResult"]]

--- a/R/mod_analysisSettings_TimeCodeWAS.R
+++ b/R/mod_analysisSettings_TimeCodeWAS.R
@@ -232,19 +232,19 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
                           "- Cohen's d = ", round(cohen_d, 3), " (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2) \n"
         )
         if (small_d) {
-          message <- paste0(message, "\u2139\uFE0F Effect size is small — practical difference may be negligible.\n")
+          message <- paste0(message, "\u2139\uFE0F Effect size is small - practical difference may be negligible.\n")
         } else {
           message <- paste0(message, "\n=> Consider controlling for year of birth by creating a new control cohort matching the case cohort by year of birth in the Match Cohorts tab.\n")
         }
       } else if (sig_t && sig_ks) {
         message <- paste0(message,
-                          "\u26A0\uFE0F There is significant difference both in the mean year of birth between case and control cohorts (t-test) — and the shapes of year of birth distributions (KS test).\n",
+                          "\u26A0\uFE0F There is significant difference both in the mean year of birth between case and control cohorts (t-test) - and the shapes of year of birth distributions (KS test).\n",
                           "- t-test p = ", scales::scientific(p_ttest), "\n",
                           "- KS test p = ", scales::scientific(p_ks), "\n",
                           "- Cohen's d = ", round(cohen_d, 3)," (mean year of birth: Cases=",round(meanCases),", Controls=",round(meanControls),". Cohen's d, the effect size of the difference in means is negligible if less than 0.2)  \n"
         )
         if (small_d) {
-          message <- paste0(message, "\u2139\uFE0F Effect size is small — practical difference may be negligible but the birth year distributions are significantly different .\n")
+          message <- paste0(message, "\u2139\uFE0F Effect size is small - practical difference may be negligible but the birth year distributions are significantly different .\n")
         }
         message <- paste0(message, "\n=> Consider controlling for year of birth by creating a new control cohort matching the case cohort by year of birth in the Match Cohorts tab.\n")
       }

--- a/R/mod_analysisSettings_TimeCodeWAS.R
+++ b/R/mod_analysisSettings_TimeCodeWAS.R
@@ -163,6 +163,7 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
       nEntryCase <- cohortTableHandler$getNumberOfCohortEntries(input$selectCaseCohort_pickerInput)
       nEntryControl <- cohortTableHandler$getNumberOfCohortEntries(input$selectControlCohort_pickerInput)
 
+
       message <- ""
       if(input$selectControlCohort_pickerInput == 0){
         message <- paste0(message, "\u2139\uFE0F Analysis will create a control cohort from the patients not in case cohort that matches case cohort by sex and birth year with ratio 1:10 and start date as in case cohort\n")
@@ -170,7 +171,7 @@ mod_analysisSettings_timeCodeWAS_server <- function(id, r_connectionHandler) {
       }
 
       # counts
-      if( nSubjectsCase > nSubjectsControl ){
+      if( nEntryCase > nEntryControl ){
         message <- paste0(message, "There are more entries in case cohort (", nEntryCase,") that in control cohort (", nEntryControl,"). Are you sure they are correct?\n")
       }
 

--- a/tests/testthat/test-mod_analysisSettings_CodeWAS.R
+++ b/tests/testthat/test-mod_analysisSettings_CodeWAS.R
@@ -29,7 +29,7 @@ test_that("mod_analysisSettings_CodeWAS works", {
         minCellCount_numericInput = 1)
 
       analysisSettings <- rf_analysisSettings()
-    
+
       analysisSettings |> assertAnalysisSettings_CodeWAS() |> expect_no_error()
       analysisSettings |> expect_equal(
         list(
@@ -49,7 +49,8 @@ test_that("mod_analysisSettings_CodeWAS works", {
       )
 
       output$info_text |> expect_match("No subjects overlap between case and control cohorts")
-      output$info_text |> expect_match("There is a significant difference in year of birth distribution between case and control cohorts")
+      output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
+
 
       # check "full" gets covariates
       session$setInputs(
@@ -83,7 +84,7 @@ test_that("mod_analysisSettings_CodeWAS works", {
 
       output$info_text |> expect_match("No subjects overlap between case and control cohorts")
       output$info_text |> expect_no_match("There is a significant difference in sex distribution between case and control cohorts")
-      output$info_text |> expect_no_match("There is a significant difference in year of birth distribution between case and control cohorts")
+      output$info_text |> expect_no_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
 
     }
   )

--- a/tests/testthat/test-mod_analysisSettings_CodeWAS.R
+++ b/tests/testthat/test-mod_analysisSettings_CodeWAS.R
@@ -2,7 +2,7 @@
 test_that("mod_analysisSettings_CodeWAS works", {
 
   # set up
-  cohortTableHandler <- helper_createNewCohortTableHandler(addCohorts = "HadesExtrasFractureCohorts")
+  cohortTableHandler <- helper_createNewCohortTableHandler(addCohorts = "EunomiaDefaultCohorts")
   withr::defer({rm(cohortTableHandler);gc()})
 
   r_connectionHandler <- shiny::reactiveValues(
@@ -48,7 +48,8 @@ test_that("mod_analysisSettings_CodeWAS works", {
         )
       )
 
-      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
+
+      output$info_text |> expect_match("There are more subjects in  case cohort|than in control cohort")
       output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
 
 
@@ -82,9 +83,7 @@ test_that("mod_analysisSettings_CodeWAS works", {
         )
       )
 
-      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
-      output$info_text |> expect_no_match("There is a significant difference in sex distribution between case and control cohorts")
-      output$info_text |> expect_no_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
+      output$info_text |> expect_match("There are more subjects in  case cohort|than in control cohort")
 
     }
   )

--- a/tests/testthat/test-mod_analysisSettings_CodeWAS.R
+++ b/tests/testthat/test-mod_analysisSettings_CodeWAS.R
@@ -2,7 +2,7 @@
 test_that("mod_analysisSettings_CodeWAS works", {
 
   # set up
-  cohortTableHandler <- helper_createNewCohortTableHandler(addCohorts = "EunomiaDefaultCohorts")
+  cohortTableHandler <- helper_createNewCohortTableHandler(addCohorts = "HadesExtrasFractureCohortsMatched")
   withr::defer({rm(cohortTableHandler);gc()})
 
   r_connectionHandler <- shiny::reactiveValues(
@@ -48,8 +48,7 @@ test_that("mod_analysisSettings_CodeWAS works", {
         )
       )
 
-
-      output$info_text |> expect_match("There are more subjects in  case cohort|than in control cohort")
+      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
       output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
 
 
@@ -83,7 +82,44 @@ test_that("mod_analysisSettings_CodeWAS works", {
         )
       )
 
-      output$info_text |> expect_match("There are more subjects in  case cohort|than in control cohort")
+      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
+
+
+      # "test subject-level comparison for matched cohorts"
+      session$setInputs(
+        selectCaseCohort_pickerInput = 1,
+        selectControlCohort_pickerInput = 2001,
+        features_pickerInput = c(101, 141, 1, 2, 402, 702, 41),
+        statistics_type_option =  "aggregated",
+        controlSex_checkboxInput = TRUE,
+        controlYearOfBirth_checkboxInput = TRUE,
+        minCellCount_numericInput = 1)
+
+      analysisSettings <- rf_analysisSettings()
+
+      analysisSettings |> assertAnalysisSettings_CodeWAS() |> expect_no_error()
+      analysisSettings |> expect_equal(
+        list(
+          cohortIdCases = 1,
+          cohortIdControls = 2001,
+          analysisIds = c(101, 141, 1, 2, 402, 702, 41),
+          covariatesIds = NULL,
+          minCellCount = 1,
+          chunksSizeNOutcomes = 5000,
+          cores = 1,
+          analysisRegexTibble = tibble::tribble(
+            ~analysisId, ~analysisName, ~analysisRegex,
+            999, "Endpoints", "^(?!.*\\[CohortLibrary\\]).*_case$",
+            998, "CohortLibrary", ".*\\[CohortLibrary\\]"
+          )
+        )
+      )
+
+      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
+      output$info_text |> expect_match("mean year of birth: Cases=1926, Controls=1933")
+      output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
+
+
 
     }
   )

--- a/tests/testthat/test-mod_analysisSettings_CodeWAS.R
+++ b/tests/testthat/test-mod_analysisSettings_CodeWAS.R
@@ -116,7 +116,7 @@ test_that("mod_analysisSettings_CodeWAS works", {
       )
 
       output$info_text |> expect_match("No subjects overlap between case and control cohorts")
-      output$info_text |> expect_match("mean year of birth: Cases=1926, Controls=1933")
+      output$info_text |> expect_match("mean year of birth: Cases=1926, Controls=1932")
       output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
 
 

--- a/tests/testthat/test-mod_analysisSettings_TimeCodeWAS.R
+++ b/tests/testthat/test-mod_analysisSettings_TimeCodeWAS.R
@@ -2,7 +2,7 @@
 test_that("mod_analysisSettings_timetimeCodeWAS works", {
 
   # set up
-  cohortTableHandler <- helper_createNewCohortTableHandler(addCohorts = "EunomiaDefaultCohorts")
+  cohortTableHandler <- helper_createNewCohortTableHandler(addCohorts = "HadesExtrasFractureCohortsMatched")
   withr::defer({rm(cohortTableHandler);gc()})
 
   r_connectionHandler <- shiny::reactiveValues(
@@ -41,9 +41,7 @@ test_that("mod_analysisSettings_timetimeCodeWAS works", {
         )
       )
 
-      #browser()
-
-      output$info_text |> expect_match("There are more subjects in  case cohort|than in control cohort")
+      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
       output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
 
       #
@@ -69,8 +67,36 @@ test_that("mod_analysisSettings_timetimeCodeWAS works", {
         )
       )
 
-      output$info_text |> expect_match("There are more subjects in  case cohort|than in control cohort")
+      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
+      output$info_text |> expect_match("There is a significant difference in sex distribution between case and control cohorts")
       output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
+
+
+      # test entry-level comparison for matched cohorts
+      session$setInputs(
+        selectCaseCohort_pickerInput = 1,
+        selectControlCohort_pickerInput = 2001,
+        features_pickerInput = c(101, 141, 1, 2, 402, 702, 41),
+        temporalStartDays = c(-1826, -365, 0, 1),
+        temporalEndDays = c(-365, 0, 1, 366),
+        minCellCount_numericInput = 1)
+
+      analysisSettings <- rf_analysisSettings()
+
+      analysisSettings |> assertAnalysisSettings_timeCodeWAS() |> expect_no_error()
+
+      analysisSettings |> expect_equal(
+        list(
+          cohortIdCases = 1,
+          cohortIdControls = 2001,
+          analysisIds = c(101, 141, 1, 2, 402, 702, 41),
+          temporalStartDays = 0,
+          temporalEndDays = 0
+        )
+      )
+
+      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
+      output$info_text |> expect_match("mean year of birth: Cases=1926, Controls=1930")
 
     }
   )

--- a/tests/testthat/test-mod_analysisSettings_TimeCodeWAS.R
+++ b/tests/testthat/test-mod_analysisSettings_TimeCodeWAS.R
@@ -42,7 +42,7 @@ test_that("mod_analysisSettings_timetimeCodeWAS works", {
       )
 
       output$info_text |> expect_match("No subjects overlap between case and control cohorts")
-      output$info_text |> expect_match("There is a significant difference in year of birth distribution between case and control cohorts")
+      output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
 
       #
       session$setInputs(

--- a/tests/testthat/test-mod_analysisSettings_TimeCodeWAS.R
+++ b/tests/testthat/test-mod_analysisSettings_TimeCodeWAS.R
@@ -2,7 +2,7 @@
 test_that("mod_analysisSettings_timetimeCodeWAS works", {
 
   # set up
-  cohortTableHandler <- helper_createNewCohortTableHandler(addCohorts = "HadesExtrasFractureCohortsMatched")
+  cohortTableHandler <- helper_createNewCohortTableHandler(addCohorts = "EunomiaDefaultCohorts")
   withr::defer({rm(cohortTableHandler);gc()})
 
   r_connectionHandler <- shiny::reactiveValues(
@@ -41,13 +41,15 @@ test_that("mod_analysisSettings_timetimeCodeWAS works", {
         )
       )
 
-      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
+      #browser()
+
+      output$info_text |> expect_match("There are more subjects in  case cohort|than in control cohort")
       output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
 
       #
       session$setInputs(
         selectCaseCohort_pickerInput = 1,
-        selectControlCohort_pickerInput = 2001,
+        selectControlCohort_pickerInput = 2,
         features_pickerInput = c(101, 141, 1, 2, 402, 702, 41),
         temporalStartDays = c(-1826, -365, 0, 1),
         temporalEndDays = c(-365, 0, 1, 366),
@@ -60,15 +62,15 @@ test_that("mod_analysisSettings_timetimeCodeWAS works", {
       analysisSettings |> expect_equal(
         list(
           cohortIdCases = 1,
-          cohortIdControls = 2001,
+          cohortIdControls = 2,
           analysisIds = c(101, 141, 1, 2, 402, 702, 41),
           temporalStartDays = 0,
           temporalEndDays = 0
         )
       )
 
-      output$info_text |> expect_match("No subjects overlap between case and control cohorts")
-      output$info_text |> expect_no_match("There is a significant difference in sex distribution between case and control cohorts")
+      output$info_text |> expect_match("There are more subjects in  case cohort|than in control cohort")
+      output$info_text |> expect_match("There is a significant difference in the shapes of year of birth distributions|There is a significant difference in the mean year of birth|There is significant difference both in the mean year of birth")
 
     }
   )


### PR DESCRIPTION
Duplicate codes in multiple files have been changed to method calls to a CohortTableHandler object. This streamlines the code base. In addition, comparison of year of birth between cohorts is now strengthened by adding Cohen's d effect size and Kolmogorov-Smirnov test (KS test) to give more insight, particularly in large sample comparisons that give significantly small p-values despite negligible effect size or similar year of birth distributions. Fixes: https://github.com/orgs/FINNGEN/projects/5/views/5?sliceBy%5Bvalue%5D=Version+1.7.0+%28DL+20+Jun.%29&filterQuery=dyohann&pane=issue&itemId=88856527&issue=FINNGEN%7CCohortOperations2%7C145